### PR TITLE
Switch terminal.MakeRaw impl to crypto/ssh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -251,9 +251,9 @@ $(portlayerapi-server): $(PORTLAYER_DEPS) $(SWAGGER)
 	@echo regenerating swagger models and operations for Portlayer API server...
 	@$(SWAGGER) generate server -A PortLayer -t $(realpath $(dir $<)) -f $<
 
-$(portlayerapi): $(call godeps,apiservers/portlayer/cmd/port-layer-server/*.go) $(portlayerapi-server) $(portlayerapi-client)
+$(portlayerapi): $(call godeps,apiservers/portlayer/cmd/port-layer-server/*.go) $(portlayerapi-client) $(portlayerapi-server)
 	@echo building Portlayer API server...
-	@$(GO) build $(RACE) -o $@ ./$(dir $<)
+	@$(GO) build $(RACE) -o $@ ./apiservers/portlayer/cmd/port-layer-server
 
 $(iso-base): isos/base.sh isos/base/*.repo isos/base/isolinux/** isos/base/xorriso-options.cfg
 	@echo building iso-base docker image

--- a/apiservers/portlayer/restapi/configure_port_layer.go
+++ b/apiservers/portlayer/restapi/configure_port_layer.go
@@ -44,6 +44,7 @@ var portlayerhandlers = []handler{
 	&handlers.MiscHandlersImpl{},
 	&handlers.ScopesHandlersImpl{},
 	&handlers.ExecHandlersImpl{},
+	&handlers.AttachHandlersImpl{},
 }
 
 func configureFlags(api *operations.PortLayerAPI) {

--- a/apiservers/portlayer/restapi/handlers/attach_handlers.go
+++ b/apiservers/portlayer/restapi/handlers/attach_handlers.go
@@ -1,0 +1,37 @@
+// Copyright 2016 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handlers
+
+import (
+	log "github.com/Sirupsen/logrus"
+	"github.com/vmware/vic/apiservers/portlayer/restapi/operations"
+	"github.com/vmware/vic/portlayer/attach"
+	"github.com/vmware/vic/portlayer/network"
+)
+
+// AttachHandlersImpl is the receiver for all container attach methods.
+type AttachHandlersImpl struct {
+	s *attach.Server
+}
+
+func (a *AttachHandlersImpl) Configure(api *operations.PortLayerAPI, dc *network.Context) {
+	// XXX this needs to live on the mgmt netwerk
+	a.s = attach.NewAttachServer("", 0)
+
+	if err := a.s.Start(); err != nil {
+		log.Fatalf("Attach server unable to start: %s", err)
+		return
+	}
+}

--- a/cmd/tether/attach.go
+++ b/cmd/tether/attach.go
@@ -24,6 +24,7 @@ import (
 	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/vic/pkg/dio"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/testdata"
 	"golang.org/x/net/context"
 )
 
@@ -93,7 +94,7 @@ func (t *attachServerSSH) start() error {
 	}
 
 	// don't assume that the key hasn't changed
-	pkey, err := ssh.ParsePrivateKey(config.Key)
+	pkey, err := ssh.ParsePrivateKey(testdata.PEMBytes["dsa"])
 	if err != nil {
 		detail := fmt.Sprintf("failed to load key for attach: %s", err)
 		log.Error(detail)
@@ -160,7 +161,7 @@ func (t *attachServerSSH) run() error {
 		t.conn = &conn
 
 		// create the SSH server
-		sConn, chans, reqs, err = ssh.NewServerConn(*t.conn, t.config)
+		sConn, chans, reqs, err = ssh.NewServerConn(conn, t.config)
 		if err != nil {
 			detail := fmt.Sprintf("failed to establish ssh handshake: %s", err)
 			log.Error(detail)

--- a/cmd/tether/main_linux.go
+++ b/cmd/tether/main_linux.go
@@ -27,6 +27,7 @@ import (
 
 func main() {
 	defer halt()
+	log.SetLevel(log.DebugLevel)
 
 	// where to look for the various devices and files related to tether
 	pathPrefix = "/.tether"

--- a/cmd/tether/tether_linux.go
+++ b/cmd/tether/tether_linux.go
@@ -168,7 +168,7 @@ func (t *osopsLinux) backchannel(ctx context.Context) (net.Conn, error) {
 	}
 
 	// HACK: currently RawConn dosn't implement timeout so throttle the spinning
-	ticker := time.NewTicker(1000 * time.Millisecond)
+	ticker := time.NewTicker(10 * time.Millisecond)
 	for {
 		select {
 		case <-ticker.C:

--- a/cmd/tether/tether_linux.go
+++ b/cmd/tether/tether_linux.go
@@ -109,15 +109,16 @@ func (t *osopsLinux) setup() error {
 	// seems necessary given rand.Reader access
 	var err error
 
-	// redirect logging to the serial log
-	log.Infof("opening %s/ttyS1 for debug log", pathPrefix)
-	out, err := os.OpenFile(pathPrefix+"/ttyS1", os.O_RDWR|os.O_SYNC|syscall.O_NOCTTY, 0777)
-	if err != nil {
-		detail := fmt.Sprintf("failed to open serial port for debug log: %s", err)
-		log.Error(detail)
-		return errors.New(detail)
-	}
-	log.SetOutput(io.MultiWriter(out, os.Stdout))
+	//
+	// // redirect logging to the serial log
+	// log.Infof("opening %s/ttyS1 for debug log", pathPrefix)
+	// out, err := os.OpenFile(pathPrefix+"/ttyS1", os.O_RDWR|os.O_SYNC|syscall.O_NOCTTY, 0777)
+	// if err != nil {
+	//	detail := fmt.Sprintf("failed to open serial port for debug log: %s", err)
+	//	log.Error(detail)
+	//	return errors.New(detail)
+	// }
+	// log.SetOutput(io.MultiWriter(out, os.Stdout))
 
 	// TODO: enabled for initial dev debugging only
 	go func() {
@@ -168,7 +169,7 @@ func (t *osopsLinux) backchannel(ctx context.Context) (net.Conn, error) {
 	}
 
 	// HACK: currently RawConn dosn't implement timeout so throttle the spinning
-	ticker := time.NewTicker(10 * time.Millisecond)
+	ticker := time.NewTicker(100 * time.Millisecond)
 	for {
 		select {
 		case <-ticker.C:
@@ -205,16 +206,17 @@ func (t *osopsLinux) processEnvOS(env []string) []string {
 // sessionLogWriter returns a writer that will persist the session output
 func (t *osopsLinux) sessionLogWriter() (dio.DynamicMultiWriter, error) {
 	// open SttyS2 for session logging
-	log.Info("opening ttyS2 for session logging")
-	f, err := os.OpenFile(pathPrefix+"/ttyS2", os.O_RDWR|os.O_SYNC|syscall.O_NOCTTY, 777)
-	if err != nil {
-		detail := fmt.Sprintf("failed to open serial port for session log: %s", err)
-		log.Error(detail)
-		return nil, errors.New(detail)
-	}
+	// log.Info("opening ttyS2 for session logging")
+	// f, err := os.OpenFile(pathPrefix+"/ttyS2", os.O_RDWR|os.O_SYNC|syscall.O_NOCTTY, 777)
+	// if err != nil {
+	//	detail := fmt.Sprintf("failed to open serial port for session log: %s", err)
+	//	log.Error(detail)
+	//	return nil, errors.New(detail)
+	// }
+	//
 
 	// use multi-writer so it goes to both screen and session log
-	return dio.MultiWriter(f, os.Stdout), nil
+	return dio.MultiWriter(os.Stdout), nil
 }
 
 func (t *osopsLinux) establishPty(live *liveSession) error {

--- a/cmd/tether/tether_test.go
+++ b/cmd/tether/tether_test.go
@@ -17,11 +17,13 @@ package main
 import (
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"net"
 	"os"
 	"path"
 	"runtime"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -154,7 +156,7 @@ func (t *mocker) backchannel(ctx context.Context) (net.Conn, error) {
 	}
 
 	// still run handshake over it to test that
-	ticker := time.NewTicker(1000 * time.Millisecond)
+	ticker := time.NewTicker(10 * time.Millisecond)
 	for {
 		select {
 		case <-ticker.C:
@@ -268,7 +270,8 @@ func testSetup(t *testing.T) {
 		cleaned: make(chan bool, 0),
 	}
 	ops = &mocked
-	utils = &mocked
+	//utils = &mocked
+	utils = &osopsLinux{}
 
 	pathPrefix, err = ioutil.TempDir("", path.Base(name))
 	if err != nil {
@@ -284,7 +287,8 @@ func testSetup(t *testing.T) {
 	log.Infof("Using %s as test prefix", pathPrefix)
 
 	backchannelMode = os.ModeNamedPipe | os.ModePerm
-	err = createFakeDevices()
+	//err = createFakeDevices()
+	err = createDevices()
 	if err != nil {
 		fmt.Println(err)
 		t.Error(err)
@@ -317,7 +321,7 @@ func testTeardown(t *testing.T) {
 }
 
 // create client on the mock pipe
-func mockSerialConnection(ctx context.Context) (net.Conn, error) {
+func mockBackChannel(ctx context.Context) (net.Conn, error) {
 	log.Info("opening ttyS0 pipe pair for backchannel")
 	c, err := os.OpenFile(pathPrefix+"/ttyS0c", os.O_RDONLY|syscall.O_NOCTTY, 0777)
 	if err != nil {
@@ -360,4 +364,47 @@ func mockSerialConnection(ctx context.Context) (net.Conn, error) {
 			return nil, ctx.Err()
 		}
 	}
+}
+
+// create client on the mock pipe and dial the given host:port
+func mockNetworkToSerialConnection(host string) (*sync.WaitGroup, error) {
+	log.Info("opening ttyS0 pipe pair for backchannel")
+	c, err := os.OpenFile(pathPrefix+"/ttyS0c", os.O_RDONLY|syscall.O_NOCTTY, 0777)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open cpipe for backchannel: %s", err)
+	}
+
+	fmt.Println("Here")
+	s, err := os.OpenFile(pathPrefix+"/ttyS0s", os.O_WRONLY|syscall.O_NOCTTY, 0777)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open spipe for backchannel: %s", err)
+	}
+
+	log.Infof("creating raw connection from ttyS0 pipe pair (c=%d, s=%d)\n", c.Fd(), s.Fd())
+	fconn, err := serial.NewHalfDuplixFileConn(c, s, pathPrefix+"/ttyS0", "file")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create raw connection from ttyS0 pipe pair: %s", err)
+	}
+
+	// Dial the attach server.  This is a TCP client
+	networkClientCon, err := net.Dial("tcp", host)
+	if err != nil {
+		return nil, err
+	}
+	log.Debugf("dialed %s", host)
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		io.Copy(networkClientCon, fconn)
+		wg.Done()
+	}()
+
+	go func() {
+		io.Copy(fconn, networkClientCon)
+		wg.Done()
+	}()
+
+	return &wg, nil
 }

--- a/pkg/serial/rawconn.go
+++ b/pkg/serial/rawconn.go
@@ -71,6 +71,7 @@ func NewTypedConn(r NamedReadChannel, w NamedWriteChannel, net string) (*RawConn
 			if err != nil {
 				return nil, err
 			}
+			break
 		}
 	}
 

--- a/pkg/serial/rawconn.go
+++ b/pkg/serial/rawconn.go
@@ -22,8 +22,9 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/crypto/ssh/terminal"
+
 	log "github.com/Sirupsen/logrus"
-	"github.com/docker/docker/pkg/term"
 )
 
 const verbose = false
@@ -65,9 +66,9 @@ func NewTypedConn(r NamedReadChannel, w NamedWriteChannel, net string) (*RawConn
 	// 0 is the uninitialized value for Fd
 	fds := []uintptr{r.Fd(), w.Fd()}
 	for _, fd := range fds {
-		if fd != 0 && term.IsTerminal(fd) {
-			log.Debug("setting terminal into raw mode")
-			_, err := term.SetRawTerminal(fd)
+		if fd != 0 && terminal.IsTerminal(int(fd)) {
+			log.Debug("setting terminal %d into raw mode", int(fd))
+			_, err := terminal.MakeRaw(int(fd))
 			if err != nil {
 				return nil, err
 			}

--- a/portlayer/attach/connector.go
+++ b/portlayer/attach/connector.go
@@ -137,22 +137,30 @@ func (c *Connector) Remove(id string) {
 
 // takes the base connection, determines the ID of the source and stashes it in the map
 func (c *Connector) processIncoming(conn net.Conn) {
+	var err error
+	defer func() {
+		if err != nil && conn != nil {
+			conn.Close()
+		}
+	}()
 
 	for {
 		if conn == nil {
 			log.Infof("connection closed")
 			return
 		}
-		defer conn.Close()
+
+		serial.PurgeIncoming(conn)
 
 		// TODO needs timeout handling.  This could take 30s.
 		ctx, cancel := context.WithTimeout(context.TODO(), 50*time.Millisecond)
-		if err := serial.HandshakeClient(ctx, conn); err == nil {
+		if err = serial.HandshakeClient(ctx, conn); err == nil {
 			log.Debugf("New connection")
 			cancel()
 			break
 		} else if err == io.EOF {
 			log.Debugf("caught EOF")
+			conn.Close()
 			return
 		}
 	}
@@ -167,21 +175,30 @@ func (c *Connector) processIncoming(conn net.Conn) {
 	}
 
 	log.Debugf("Initiating ssh handshake with new connection attempt")
-	ccon, newchan, request, err := ssh.NewClientConn(conn, "", config)
+	var (
+		ccon    ssh.Conn
+		newchan <-chan ssh.NewChannel
+		request <-chan *ssh.Request
+	)
+
+	ccon, newchan, request, err = ssh.NewClientConn(conn, "", config)
 	if err != nil {
 		log.Errorf("SSH connection could not be established: %s", errors.ErrorStack(err))
 		return
 	}
 
 	client := ssh.NewClient(ccon, newchan, request)
-	ids, err := SSHls(client)
+
+	var ids []string
+	ids, err = SSHls(client)
 	if err != nil {
 		log.Errorf("SSH connection could not be established: %s", errors.ErrorStack(err))
 		return
 	}
 
 	for _, id := range ids {
-		si, err := SSHAttach(client, id)
+		var si SessionInteraction
+		si, err = SSHAttach(client, id)
 		if err != nil {
 			log.Errorf("SSH connection could not be established (id=%s): %s", id, errors.ErrorStack(err))
 			return

--- a/portlayer/attach/connector.go
+++ b/portlayer/attach/connector.go
@@ -153,7 +153,7 @@ func (c *Connector) processIncoming(conn net.Conn) {
 		serial.PurgeIncoming(conn)
 
 		// TODO needs timeout handling.  This could take 30s.
-		ctx, cancel := context.WithTimeout(context.TODO(), 50*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.TODO(), 500*time.Millisecond)
 		if err = serial.HandshakeClient(ctx, conn); err == nil {
 			log.Debugf("New connection")
 			cancel()
@@ -247,6 +247,7 @@ func (c *Connector) serve() {
 			continue
 		}
 
+		log.Info("Received incoming connection")
 		go c.processIncoming(conn)
 	}
 }

--- a/portlayer/attach/server.go
+++ b/portlayer/attach/server.go
@@ -17,6 +17,9 @@ package attach
 import (
 	"fmt"
 	"net"
+	"time"
+
+	"golang.org/x/net/context"
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/vmware/vic/pkg/errors"
@@ -69,4 +72,12 @@ func (n *Server) Stop() error {
 	err := n.l.Close()
 	n.connServer.Stop()
 	return err
+}
+
+func (n *Server) Addr() string {
+	return n.l.Addr().String()
+}
+
+func (n *Server) Get(ctx context.Context, id string, timeout time.Duration) (*Connection, error) {
+	return n.connServer.Get(ctx, id, timeout)
 }

--- a/portlayer/attach/server_test.go
+++ b/portlayer/attach/server_test.go
@@ -42,6 +42,12 @@ func TestAttachStartStop(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNil(t, c)
 
+		buf := make([]byte, 1)
+		c.Read(buf)
+		if !assert.Error(t, serial.HandshakeServer(context.Background(), c)) {
+			return
+		}
+
 		if !assert.NoError(t, serial.HandshakeServer(context.Background(), c)) {
 			return
 		}

--- a/portlayer/attach/server_test.go
+++ b/portlayer/attach/server_test.go
@@ -80,8 +80,8 @@ func TestAttachStartStop(t *testing.T) {
 
 func TestAttachSshSession(t *testing.T) {
 	log.SetLevel(log.InfoLevel)
-	s := NewAttachServer("", -1)
 
+	s := NewAttachServer("", -1)
 	assert.NoError(t, s.Start())
 	defer s.Stop()
 

--- a/vendor/golang.org/x/crypto/ssh/handshake.go
+++ b/vendor/golang.org/x/crypto/ssh/handshake.go
@@ -17,7 +17,7 @@ import (
 // debugHandshake, if set, prints messages sent and received.  Key
 // exchange messages are printed as if DH were used, so the debug
 // messages are wrong when using ECDH.
-const debugHandshake = false
+const debugHandshake = true
 
 // keyingTransport is a packet based transport that supports key
 // changes. It need not be thread-safe. It should pass through

--- a/vendor/golang.org/x/crypto/ssh/mux.go
+++ b/vendor/golang.org/x/crypto/ssh/mux.go
@@ -15,7 +15,7 @@ import (
 
 // debugMux, if set, causes messages in the connection protocol to be
 // logged.
-const debugMux = false
+const debugMux = true
 
 // chanList is a thread safe channel list.
 type chanList struct {


### PR DESCRIPTION
Looks like people have been messing around in the docker/docker/pkg/term impl and I'm suspicious of it. The last time I remember looking at this it was not using the cgo impl I see in there now.

This moves to the x/crypto/ssh/terminal impl for MakeRaw... worth trying. Also worth noting that it doesn't have the handler to revert the terminal config which could be problematic for us.
